### PR TITLE
Feature/29 show alternatives in hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Alternatives shown after correct typing answer** — after typing a correct answer in typing-quiz mode, if the word has multiple accepted answers, the full answer string (showing all alternatives) is shown in the hint area below the result.
+- **Alternatives shown after correct typing answer** — after typing a correct answer in typing-quiz mode, if the word has multiple accepted answers, the full answer string (showing all alternatives) is shown in the additional info area below the result.
 - **Switch to options in typing mode** — a "Switch to options" button is now shown during typing-mode quizzes. Clicking it immediately applies a maximum weight penalty (100) to the word, closes the typing window, and opens a standard multiple-choice quiz for the same word. The switch applies only to the current question; the next quiz continues in typing mode.
 
 ## [1.1.0] - 2026-05-07
@@ -15,7 +15,7 @@
 
 ### Added
 
-- **Answer hint after correct answer** — in multiple-choice mode, when the correct answer contains parenthetical content (e.g. "the current (water, air, electricity)"), the full unstripped answer is shown as a hint below the result message after the user answers correctly.
+- **Answer additional info after correct answer** — in multiple-choice mode, when the correct answer contains parenthetical content (e.g. "the current (water, air, electricity)"), the full unstripped answer is shown as an additional info below the result message after the user answers correctly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **Alternatives shown after correct typing answer** — after typing a correct answer in typing-quiz mode, if the word has multiple accepted answers, the full answer string (showing all alternatives) is shown in the hint area below the result.
 - **Switch to options in typing mode** — a "Switch to options" button is now shown during typing-mode quizzes. Clicking it immediately applies a maximum weight penalty (100) to the word, closes the typing window, and opens a standard multiple-choice quiz for the same word. The switch applies only to the current question; the next quiz continues in typing mode.
 
 ## [1.1.0] - 2026-05-07

--- a/ViewModels/QuizViewModel.cs
+++ b/ViewModels/QuizViewModel.cs
@@ -25,7 +25,7 @@ public class QuizViewModel : ViewModelBase
     private string _resultMessage = string.Empty;
     private string _resultColor = ColorDefault;
     private bool _isQuizCompleted;
-    private bool _isHintVisible;
+    private bool _isAdditionalInfoVisible;
 
     /// <summary>
     /// Gets the question text to display.
@@ -69,18 +69,18 @@ public class QuizViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Gets the full unstripped answer string (including bracket content) for display as a hint.
+    /// Gets the full unstripped answer string (including bracket content) shown after a correct answer.
     /// </summary>
-    public string HintText => _session.Quiz.WordEntry.Answer;
+    public string AdditionalInfo => _session.Quiz.WordEntry.Answer;
 
     /// <summary>
-    /// Gets a value indicating whether the answer hint should be visible.
+    /// Gets a value indicating whether the additional info should be visible.
     /// True only after a correct answer when the answer contains parenthetical content.
     /// </summary>
-    public bool IsHintVisible
+    public bool IsAdditionalInfoVisible
     {
-        get => _isHintVisible;
-        private set => SetProperty(ref _isHintVisible, value);
+        get => _isAdditionalInfoVisible;
+        private set => SetProperty(ref _isAdditionalInfoVisible, value);
     }
 
     /// <summary>
@@ -118,7 +118,7 @@ public class QuizViewModel : ViewModelBase
                 ResultMessage = "Correct!";
                 ResultColor = ColorCorrect;
                 IsQuizCompleted = true;
-                IsHintVisible = _session.Quiz.WordEntry.Answer != _session.Quiz.WordEntry.CanonicalAnswer;
+                IsAdditionalInfoVisible = _session.Quiz.WordEntry.Answer != _session.Quiz.WordEntry.CanonicalAnswer;
                 StartAutoCloseTimer();
                 break;
 

--- a/ViewModels/TypingQuizViewModel.cs
+++ b/ViewModels/TypingQuizViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Threading;
 using VocabularyTrainer.Models;
 using VocabularyTrainer.Services;
 using VocabularyTrainer.Services.Quiz.Presenters;
+using VocabularyTrainer.Services.Utils;
 using Timer = System.Timers.Timer;
 
 namespace VocabularyTrainer.ViewModels;
@@ -141,7 +142,8 @@ public class TypingQuizViewModel : ViewModelBase
                 ResultMessage = "Correct!";
                 ResultColor = ColorCorrect;
                 IsQuizCompleted = true;
-                IsAnswerHintVisible = _session.Quiz.WordEntry.Answer != _session.Quiz.WordEntry.CanonicalAnswer;
+                IsAnswerHintVisible = _session.Quiz.WordEntry.Answer != _session.Quiz.WordEntry.CanonicalAnswer
+                    || AnswerParser.Options(_session.Quiz.WordEntry.Answer).Count > 1;
                 SubmitCommand.RaiseCanExecuteChanged();
                 StartAutoCloseTimer();
                 break;

--- a/ViewModels/TypingQuizViewModel.cs
+++ b/ViewModels/TypingQuizViewModel.cs
@@ -28,7 +28,7 @@ public class TypingQuizViewModel : ViewModelBase
     private string _resultMessage = string.Empty;
     private string _resultColor = ColorDefault;
     private bool _isQuizCompleted;
-    private bool _isAnswerHintVisible;
+    private bool _isAdditionalInfoVisible;
 
     /// <summary>
     /// Gets the question text to display.
@@ -85,18 +85,18 @@ public class TypingQuizViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Gets the full unstripped answer string (including bracket content) for display as a hint.
+    /// Gets the full unstripped answer string (including bracket content) shown after a correct answer.
     /// </summary>
-    public string AnswerHintText => _session.Quiz.WordEntry.Answer;
+    public string AdditionalInfo => _session.Quiz.WordEntry.Answer;
 
     /// <summary>
-    /// Gets a value indicating whether the answer hint should be visible.
-    /// True only after a correct answer when the answer contains parenthetical content.
+    /// Gets a value indicating whether the additional info should be visible.
+    /// True only after a correct answer when the answer contains parenthetical content or multiple options.
     /// </summary>
-    public bool IsAnswerHintVisible
+    public bool IsAdditionalInfoVisible
     {
-        get => _isAnswerHintVisible;
-        private set => SetProperty(ref _isAnswerHintVisible, value);
+        get => _isAdditionalInfoVisible;
+        private set => SetProperty(ref _isAdditionalInfoVisible, value);
     }
 
     /// <summary>
@@ -142,7 +142,7 @@ public class TypingQuizViewModel : ViewModelBase
                 ResultMessage = "Correct!";
                 ResultColor = ColorCorrect;
                 IsQuizCompleted = true;
-                IsAnswerHintVisible = _session.Quiz.WordEntry.Answer != _session.Quiz.WordEntry.CanonicalAnswer
+                IsAdditionalInfoVisible = _session.Quiz.WordEntry.Answer != _session.Quiz.WordEntry.CanonicalAnswer
                     || AnswerParser.Options(_session.Quiz.WordEntry.Answer).Count > 1;
                 SubmitCommand.RaiseCanExecuteChanged();
                 StartAutoCloseTimer();

--- a/Views/QuizView.axaml
+++ b/Views/QuizView.axaml
@@ -39,7 +39,7 @@
             <Setter Property="Margin" Value="0,12,0,0"/>
         </Style>
 
-        <Style Selector="TextBlock.hint">
+        <Style Selector="TextBlock.additional-info">
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="Foreground" Value="#666666"/>
             <Setter Property="TextAlignment" Value="Center"/>
@@ -83,9 +83,9 @@
                            Classes="result"
                            IsVisible="{Binding ResultMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
-                <TextBlock Text="{Binding HintText}"
-                           IsVisible="{Binding IsHintVisible}"
-                           Classes="hint"/>
+                <TextBlock Text="{Binding AdditionalInfo}"
+                           IsVisible="{Binding IsAdditionalInfoVisible}"
+                           Classes="additional-info"/>
             </StackPanel>
     </DockPanel>
 </Window>

--- a/Views/TypingQuizView.axaml
+++ b/Views/TypingQuizView.axaml
@@ -61,7 +61,7 @@
             <Setter Property="Margin" Value="0,8,0,0"/>
         </Style>
 
-        <Style Selector="TextBlock.answer-hint">
+        <Style Selector="TextBlock.additional-info">
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="Foreground" Value="#666666"/>
             <Setter Property="TextAlignment" Value="Center"/>
@@ -124,9 +124,9 @@
                            Classes="result"
                            IsVisible="{Binding ResultMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
-                <TextBlock Text="{Binding AnswerHintText}"
-                           IsVisible="{Binding IsAnswerHintVisible}"
-                           Classes="answer-hint"/>
+                <TextBlock Text="{Binding AdditionalInfo}"
+                           IsVisible="{Binding IsAdditionalInfoVisible}"
+                           Classes="additional-info"/>
             </StackPanel>
         </DockPanel>
     </Panel>

--- a/VocabularyTrainer.Tests/ViewModels/QuizViewModelTests.cs
+++ b/VocabularyTrainer.Tests/ViewModels/QuizViewModelTests.cs
@@ -22,59 +22,59 @@ public class QuizViewModelTests : IDisposable
 
     public void Dispose() => File.Delete(_tempFile);
 
-    // ── HintText ──────────────────────────────────────────────────────────────
+    // ── AdditionalInfo ────────────────────────────────────────────────────────
 
     [Fact]
-    public void HintText_IsFullUnstrippedAnswer()
+    public void AdditionalInfo_IsFullUnstrippedAnswer()
     {
         var word = WordEntryFixture.Make("stroom", "the current (water, air, electricity)");
         var vm = MakeViewModel(word);
 
-        vm.HintText.Should().Be("the current (water, air, electricity)");
+        vm.AdditionalInfo.Should().Be("the current (water, air, electricity)");
     }
 
-    // ── IsHintVisible ─────────────────────────────────────────────────────────
+    // ── IsAdditionalInfoVisible ───────────────────────────────────────────────
 
     [Fact]
-    public void IsHintVisible_IsFalse_BeforeAnswering()
+    public void IsAdditionalInfoVisible_IsFalse_BeforeAnswering()
     {
         var word = WordEntryFixture.Make("stroom", "the current (water, air, electricity)");
         var vm = MakeViewModel(word);
 
-        vm.IsHintVisible.Should().BeFalse();
+        vm.IsAdditionalInfoVisible.Should().BeFalse();
     }
 
     [Fact]
-    public void IsHintVisible_IsTrue_AfterCorrectAnswer_WhenAnswerHasBrackets()
+    public void IsAdditionalInfoVisible_IsTrue_AfterCorrectAnswer_WhenAnswerHasBrackets()
     {
         var word = WordEntryFixture.Make("stroom", "the current (water, air, electricity)");
         var vm = MakeViewModel(word);
 
         vm.AnswerCommand.Execute("the current");
 
-        vm.IsHintVisible.Should().BeTrue();
+        vm.IsAdditionalInfoVisible.Should().BeTrue();
     }
 
     [Fact]
-    public void IsHintVisible_IsFalse_AfterCorrectAnswer_WhenAnswerHasNoBrackets()
+    public void IsAdditionalInfoVisible_IsFalse_AfterCorrectAnswer_WhenAnswerHasNoBrackets()
     {
         var word = WordEntryFixture.Make("hond", "dog");
         var vm = MakeViewModel(word);
 
         vm.AnswerCommand.Execute("dog");
 
-        vm.IsHintVisible.Should().BeFalse();
+        vm.IsAdditionalInfoVisible.Should().BeFalse();
     }
 
     [Fact]
-    public void IsHintVisible_IsFalse_AfterWrongAnswer()
+    public void IsAdditionalInfoVisible_IsFalse_AfterWrongAnswer()
     {
         var word = WordEntryFixture.Make("stroom", "the current (water, air, electricity)");
         var vm = MakeViewModel(word);
 
         vm.AnswerCommand.Execute("wrong answer");
 
-        vm.IsHintVisible.Should().BeFalse();
+        vm.IsAdditionalInfoVisible.Should().BeFalse();
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/VocabularyTrainer.Tests/ViewModels/TypingQuizViewModelTests.cs
+++ b/VocabularyTrainer.Tests/ViewModels/TypingQuizViewModelTests.cs
@@ -50,7 +50,9 @@ public class TypingQuizViewModelTests : IDisposable
     [Theory]
     [InlineData("stroom", "the current (water, air, electricity)", null)]          // before answering
     [InlineData("stroom", "the current (water, air, electricity)", "wrong answer")] // wrong answer
-    [InlineData("hond",   "dog",                                   "dog")]          // correct, no brackets
+    [InlineData("hond",   "dog",                                   "dog")]          // correct, no brackets, single option
+    [InlineData("getal",  "the number, the amount",                null)]           // before answering, multiple options
+    [InlineData("getal",  "the number, the amount",                "wrong answer")] // wrong answer, multiple options
     public void IsAnswerHintVisible_IsFalse(string question, string answer, string? typed)
     {
         var word = WordEntryFixture.Make(question, answer);
@@ -63,6 +65,29 @@ public class TypingQuizViewModelTests : IDisposable
         }
 
         vm.IsAnswerHintVisible.Should().BeFalse();
+    }
+
+    // ── IsAnswerHintVisible — multiple options ────────────────────────────────
+
+    [Fact]
+    public void IsAnswerHintVisible_IsTrue_AfterCorrectAnswer_WhenAnswerHasMultipleOptions()
+    {
+        var word = WordEntryFixture.Make("getal", "the number, the amount");
+        var vm = MakeViewModel(word);
+
+        vm.TextInput = "the number";
+        vm.SubmitCommand.Execute(null);
+
+        vm.IsAnswerHintVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnswerHintText_IsFullAnswer_WhenMultipleOptions()
+    {
+        var word = WordEntryFixture.Make("getal", "the number, the amount");
+        var vm = MakeViewModel(word);
+
+        vm.AnswerHintText.Should().Be("the number, the amount");
     }
 
     // ── SwitchToOptionsCommand ────────────────────────────────────────────────

--- a/VocabularyTrainer.Tests/ViewModels/TypingQuizViewModelTests.cs
+++ b/VocabularyTrainer.Tests/ViewModels/TypingQuizViewModelTests.cs
@@ -22,21 +22,21 @@ public class TypingQuizViewModelTests : IDisposable
 
     public void Dispose() => File.Delete(_tempFile);
 
-    // ── AnswerHintText ────────────────────────────────────────────────────────
+    // ── AdditionalInfo ────────────────────────────────────────────────────────
 
     [Fact]
-    public void AnswerHintText_IsFullUnstrippedAnswer()
+    public void AdditionalInfo_IsFullUnstrippedAnswer()
     {
         var word = WordEntryFixture.Make("stroom", "the current (water, air, electricity)");
         var vm = MakeViewModel(word);
 
-        vm.AnswerHintText.Should().Be("the current (water, air, electricity)");
+        vm.AdditionalInfo.Should().Be("the current (water, air, electricity)");
     }
 
-    // ── IsAnswerHintVisible ───────────────────────────────────────────────────
+    // ── IsAdditionalInfoVisible ───────────────────────────────────────────────
 
     [Fact]
-    public void IsAnswerHintVisible_IsTrue_AfterCorrectAnswer_WhenAnswerHasBrackets()
+    public void IsAdditionalInfoVisible_IsTrue_AfterCorrectAnswer_WhenAnswerHasBrackets()
     {
         var word = WordEntryFixture.Make("stroom", "the current (water, air, electricity)");
         var vm = MakeViewModel(word);
@@ -44,7 +44,7 @@ public class TypingQuizViewModelTests : IDisposable
         vm.TextInput = "the current";
         vm.SubmitCommand.Execute(null);
 
-        vm.IsAnswerHintVisible.Should().BeTrue();
+        vm.IsAdditionalInfoVisible.Should().BeTrue();
     }
 
     [Theory]
@@ -53,7 +53,7 @@ public class TypingQuizViewModelTests : IDisposable
     [InlineData("hond",   "dog",                                   "dog")]          // correct, no brackets, single option
     [InlineData("getal",  "the number, the amount",                null)]           // before answering, multiple options
     [InlineData("getal",  "the number, the amount",                "wrong answer")] // wrong answer, multiple options
-    public void IsAnswerHintVisible_IsFalse(string question, string answer, string? typed)
+    public void IsAdditionalInfoVisible_IsFalse(string question, string answer, string? typed)
     {
         var word = WordEntryFixture.Make(question, answer);
         var vm = MakeViewModel(word);
@@ -64,13 +64,13 @@ public class TypingQuizViewModelTests : IDisposable
             vm.SubmitCommand.Execute(null);
         }
 
-        vm.IsAnswerHintVisible.Should().BeFalse();
+        vm.IsAdditionalInfoVisible.Should().BeFalse();
     }
 
-    // ── IsAnswerHintVisible — multiple options ────────────────────────────────
+    // ── IsAdditionalInfoVisible — multiple options ────────────────────────────
 
     [Fact]
-    public void IsAnswerHintVisible_IsTrue_AfterCorrectAnswer_WhenAnswerHasMultipleOptions()
+    public void IsAdditionalInfoVisible_IsTrue_AfterCorrectAnswer_WhenAnswerHasMultipleOptions()
     {
         var word = WordEntryFixture.Make("getal", "the number, the amount");
         var vm = MakeViewModel(word);
@@ -78,16 +78,16 @@ public class TypingQuizViewModelTests : IDisposable
         vm.TextInput = "the number";
         vm.SubmitCommand.Execute(null);
 
-        vm.IsAnswerHintVisible.Should().BeTrue();
+        vm.IsAdditionalInfoVisible.Should().BeTrue();
     }
 
     [Fact]
-    public void AnswerHintText_IsFullAnswer_WhenMultipleOptions()
+    public void AdditionalInfo_IsFullAnswer_WhenMultipleOptions()
     {
         var word = WordEntryFixture.Make("getal", "the number, the amount");
         var vm = MakeViewModel(word);
 
-        vm.AnswerHintText.Should().Be("the number, the amount");
+        vm.AdditionalInfo.Should().Be("the number, the amount");
     }
 
     // ── SwitchToOptionsCommand ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #29

## Checklist

- [x] The linked issue has been labeled `accepted` by the maintainer
- [x] `dotnet test` passes locally
- [x] Business logic changes include unit tests
- [x] Bug fixes include a regression test
- [x] Changes are limited to the scope of the linked issue
